### PR TITLE
Updated scala, akka, scalatest and zeromq versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Currently it only supports receiving data via unidirectional ZMQ sockets of type
 
 # ZMQ compatibility
 
-See [jeromq](https://github.com/zeromq/jeromq/tree/v0.3.5) documentation.  
+See [jeromq](https://github.com/zeromq/jeromq/tree/v0.4.2) documentation.
 
 # 30 seconds start
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,16 +2,16 @@ name := "reactive-zmq"
 
 organization := "ru.dgis"
 
-val akkaVersion = "2.4.4"
+val akkaVersion = "2.5.3"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.11.11"
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor" % akkaVersion,
   "com.typesafe.akka" %% "akka-stream" % akkaVersion,
-  "org.zeromq" % "jeromq" % "0.3.5",
+  "org.zeromq" % "jeromq" % "0.4.2",
   "org.mockito" % "mockito-core" % "1.10.19" % "test",
-  "org.scalatest" %% "scalatest" % "2.2.6" % "test",
+  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
   "com.typesafe.akka" %% "akka-testkit" % akkaVersion % "test",
   "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % "test",
   "org.scalacheck" %% "scalacheck" % "1.13.1" % "test"


### PR DESCRIPTION
I checked [akka migration guide](http://doc.akka.io/docs/akka/current/scala/project/migration-guide-2.4.x-2.5.x.html) and [zmq changelog](https://github.com/zeromq/jeromq/blob/master/CHANGELOG.md) and don't found any incompatibilities in the current codebase. So, no code changes, only lib versions update.