### PR TITLE
gracefulStop now returns Future

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ val (control, finish) = source
 The `Control` object exposes a `gracefulStop` method that closes an underlying ZMQ socket and completes the `Source`:
 
 ```scala
-control.gracefulStop()
+val stopFuture: Future[Unit] = control.gracefulStop()
 
 implicit val ec = as.dispatcher
-finish.onComplete { _ =>
+Future.sequence(Seq(stopFuture, finish)).onComplete { _ =>
   as.terminate()
   context.close()
 }

--- a/build.sbt
+++ b/build.sbt
@@ -10,10 +10,12 @@ crossScalaVersions := Seq("2.11.11", "2.12.3")
 
 scalacOptions ++= Seq("-feature", "-deprecation", "-Xlint")
 
+resolvers += Resolver.sonatypeRepo("snapshots") // FIXME: for jeromq snapshot
+
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor"          % akkaVersion,
   "com.typesafe.akka" %% "akka-stream"         % akkaVersion,
-  "org.zeromq"        %  "jeromq"              % "0.4.2",
+  "org.zeromq"        %  "jeromq"              % "0.4.3-SNAPSHOT", // FIXME: https://github.com/zeromq/jeromq/issues/466#issuecomment-328910616
   "org.mockito"       %  "mockito-core"        % "2.8.47"     % "test",
   "org.scalatest"     %% "scalatest"           % "3.0.1"      % "test",
   "com.typesafe.akka" %% "akka-testkit"        % akkaVersion  % "test",

--- a/src/test/scala/ru/dgis/reactivezmq/Examples.scala
+++ b/src/test/scala/ru/dgis/reactivezmq/Examples.scala
@@ -6,6 +6,7 @@ import akka.stream.scaladsl._
 import akka.util.ByteString
 import org.zeromq.ZMQ
 
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.DurationInt
 
 /**
@@ -33,9 +34,8 @@ object Examples extends App {
     .toMat(Sink.ignore)(Keep.both)
     .run()
 
-  implicit val ec = as.dispatcher
-  control.gracefulStop()
-  finish.onComplete { _ =>
+  implicit val ec = ExecutionContext.Implicits.global
+  Future.sequence(Seq(control.gracefulStop(), finish)).onComplete { _ =>
     as.terminate()
     context.close()
   }


### PR DESCRIPTION
* Changed the return value of `gracefulStop` method from `Unit` to `Future[Unit]`. It gives the possibility to wait for the exact moment of source completion.
* Added tests and renew old tests.
* Fixed example and readme.
* Also bumped version of jeromq to 0.4.3-SHAPSHOT, because 0.4.2 version contains [important issue](https://github.com/zeromq/jeromq/issues/466).